### PR TITLE
pass opts through to township

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # dat-registry-client
 
-API Registry Client for publishing dats
+API Registry Client for publishing dats.
+
+## Installation
+
+```
+npm install dat-registry
+```
 
 ### Quick Example
 
@@ -28,7 +34,23 @@ registry.login({email: 'karissa', password: 'my passw0rd r0cks!'}, function () {
 
 #### `var registry = Registry([opts])`
 
-  * `opts.server`: the server to query. Default is `https://datproject.org`
+  * `opts.server`: the server to query. Default is `https://datproject.org/api/v1`
+
+Other options are passed to [township-client](https://github.com/township/township-client), these include:
+
+```js
+opts = {
+  config: {
+    filename: '.townshiprc', // configuration filename (stored in os homedir)
+    filepath: '~/.townshiprc' // specify a full config file path 
+  },
+  routes: { // routes for ALL township servers used by client
+    register: '/register',
+    login: '/login',
+    updatePassword: '/updatepassword'
+  }
+}
+```
 
 #### `registry.login(data, cb)`
 

--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ function API (opts) {
   if (!opts) opts = {}
   var server = opts.server || 'https://datproject.org'
   var api = server + '/api/v1'
-  var township = Township({
-    server: api
-  })
+  var township = Township(xtend(opts, {
+    server: api // used over opts.server
+  }))
   return {
     login: township.login.bind(township),
     logout: township.logout.bind(township),


### PR DESCRIPTION
We use the township `opts.config` in the CLI. Pass that through here to township, but keep `opts.server` with the default.