### PR TITLE
Change how default server is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# dat-registry-client
+# dat-registry
 
-API Registry Client for publishing dats.
+API Registry Client for publishing dats. By default, the client is capable of registering, login, and publishing to datproject.org.
+
+`dat-registry` allows users to interact with and publish dats to your registry via the `dat` command line. Supporting this module on your registry will allow a user to login and publish:
+
+```
+dat login custom-dat-registry.com
+dat publish
+```
 
 ## Installation
 
@@ -34,14 +41,15 @@ registry.login({email: 'karissa', password: 'my passw0rd r0cks!'}, function () {
 
 #### `var registry = Registry([opts])`
 
-  * `opts.server`: the server to query. Default is `https://datproject.org/api/v1`
+  * `opts.server`: the registry server. Default is `https://datproject.org`
+  * `opts.apiPath`: registery server API path, e.g. we use `/api/v1` for datproject.org. This will overwrite default township routes to use server + apiPath.
+  * `opts.config.filename`: defaults to `~.datrc` instead of township defaults.
 
 Other options are passed to [township-client](https://github.com/township/township-client), these include:
 
 ```js
 opts = {
   config: {
-    filename: '.townshiprc', // configuration filename (stored in os homedir)
     filepath: '~/.townshiprc' // specify a full config file path 
   },
   routes: { // routes for ALL township servers used by client
@@ -67,7 +75,6 @@ Will callback with logout success or failure.
 #### `var user = registry.whoami([opts])`
 
 Returns user object with currently logged in user. See `township-client` for options.
-
 
 ### CRUD API
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function API (opts) {
   var SERVER = 'https://datproject.org'
   var API_PATH = '/api/v1'
 
-  var apiPath = opts.server.indexOf('datproject.org') === -1 ? opts.apiPath : API_PATH // only add default path to datproject.org server
+  var apiPath = (opts.server && opts.server.indexOf('datproject.org') > -1) ? API_PATH: opts.apiPath // only add default path to datproject.org server
   var townshipOpts = Object.assign({}, opts)
 
   // set default township server & routes for datproject.org

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function API (opts) {
   var SERVER = 'https://datproject.org'
   var API_PATH = '/api/v1'
 
-  var apiPath = opts.server ? opts.apiPath : API_PATH // only add default path to datproject.org server
+  var apiPath = opts.server.indexOf('datproject.org') === -1 ? opts.apiPath : API_PATH // only add default path to datproject.org server
   var townshipOpts = Object.assign({}, opts)
 
   // set default township server & routes for datproject.org

--- a/index.js
+++ b/index.js
@@ -8,11 +8,28 @@ module.exports = API
 function API (opts) {
   if (!(this instanceof API)) return new API(opts)
   if (!opts) opts = {}
-  var server = opts.server || 'https://datproject.org'
-  var api = server + '/api/v1'
-  var township = Township(xtend(opts, {
-    server: api // used over opts.server
-  }))
+
+  // datproject.org defaults, specify opts.server and opts.apiPath to override
+  var SERVER = 'https://datproject.org'
+  var API_PATH = '/api/v1'
+
+  var apiPath = opts.server ? opts.apiPath : API_PATH // only add default path to datproject.org server
+  var townshipOpts = Object.assign({}, opts)
+
+  // set default township server & routes for datproject.org
+  if (!townshipOpts.config.filename) townshipOpts.config.filename = '.datrc'
+  if (!townshipOpts.server) townshipOpts.server = SERVER
+  if (!opts.routes && !opts.server) {
+    townshipOpts.routes = {
+      register: apiPath + '/register',
+      login: apiPath + '/login',
+      updatePassword: apiPath + '/updatepassword'
+    }
+  }
+
+  var api = townshipOpts.server + apiPath
+  var township = Township(townshipOpts)
+
   return {
     login: township.login.bind(township),
     logout: township.logout.bind(township),

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function API (opts) {
   // set default township server & routes for datproject.org
   if (!townshipOpts.config.filename) townshipOpts.config.filename = '.datrc'
   if (!townshipOpts.server) townshipOpts.server = SERVER
-  if (!opts.routes && !opts.server) {
+  if (!opts.routes && apiPath) {
     townshipOpts.routes = {
       register: apiPath + '/register',
       login: apiPath + '/login',


### PR DESCRIPTION
Make it easier to use other servers in dat CLI:

* Store `opts.server` in config file (instead of full path)
* Add `opts.apiPath` option, so we can customize routes without storing in config file
* Make it clear servers can be customized
* Use `~/.datrc` by default