### PR TITLE
minor bug fixes with server parsing + required id

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function API (opts) {
   var SERVER = 'https://datproject.org'
   var API_PATH = '/api/v1'
 
-  var apiPath = !opts.server || (opts.server.indexOf('datproject.org') > -1) ? API_PATH: opts.apiPath // only add default path to datproject.org server
+  var apiPath = !opts.server || (opts.server.indexOf('datproject.org') > -1) ? API_PATH : opts.apiPath // only add default path to datproject.org server
   var townshipOpts = Object.assign({}, opts)
 
   // set default township server & routes for datproject.org
@@ -39,10 +39,10 @@ function API (opts) {
     secureRequest: township.secureRequest.bind(township),
     dats: rest('/dats'),
     users: xtend(rest('/users'), {
-      resetPassword: function(input, cb) {
+      resetPassword: function (input, cb) {
         nets({method: 'POST', uri: api + '/password-reset', body: input, json: true}, cb)
       },
-      resetPasswordConfirmation: function(input, cb) {
+      resetPasswordConfirmation: function (input, cb) {
         nets({method: 'POST', uri: api + '/password-reset-confirm', body: input, json: true}, cb)
       }
     })

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function API (opts) {
   var SERVER = 'https://datproject.org'
   var API_PATH = '/api/v1'
 
-  var apiPath = (opts.server && opts.server.indexOf('datproject.org') > -1) ? API_PATH: opts.apiPath // only add default path to datproject.org server
+  var apiPath = !opts.server || (opts.server.indexOf('datproject.org') > -1) ? API_PATH: opts.apiPath // only add default path to datproject.org server
   var townshipOpts = Object.assign({}, opts)
 
   // set default township server & routes for datproject.org
@@ -28,8 +28,8 @@ function API (opts) {
     }
   }
 
-  var api = townshipOpts.server + apiPath
   var township = Township(townshipOpts)
+  var api = township.server + apiPath // let township parse server
 
   return {
     login: township.login.bind(township),
@@ -68,14 +68,12 @@ function API (opts) {
         township.secureRequest(opts, cb)
       },
       update: function (input, cb) {
-        if (!input.id) throw new Error('id required')
         var opts = Object.assign({}, defaults)
         opts.body = input
         opts.method = 'PUT'
         township.secureRequest(opts, cb)
       },
       delete: function (input, cb) {
-        if (!input.id) throw new Error('id required')
         var opts = Object.assign({}, defaults)
         opts.body = input
         opts.method = 'DELETE'


### PR DESCRIPTION
* make sure to set `apiPath` to default if no server
* use township server parsing for `api` to get full uri (adds https, etc.)
* remove `id` checks in delete + update. We either use logged in user information (and `dat.name` for dats).